### PR TITLE
Update PostgreSQLAdapter to work with jdbc-postgres

### DIFF
--- a/lib/spectacles/schema_statements/postgresql_adapter.rb
+++ b/lib/spectacles/schema_statements/postgresql_adapter.rb
@@ -13,7 +13,7 @@ module Spectacles
            AND table_type = 'VIEW'
         SQL
         
-        query(q, name).map { |row| row[0] }
+        execute(q, name).map { |row| row['table_name'] }
       end
 
       def view_build_query(view, name = nil)


### PR DESCRIPTION
When running in jRuby, the PostgreSQLAdapter does not have a `query` method. Changing this to `execute` and altering the map works in MRI and jRuby

``` text
undefined method 'query' for <ActiveRecord::ConnectionAdapters::PostgreSQLAdapter:0x7974c669>
[project]/vendor/gems/spectacles/lib/spectacles/schema_statements/postgresql_adapter.rb:16:in `views'
[project]/vendor/gems/spectacles/lib/spectacles/schema_dumper.rb:4:in `dump_views'
[project]/vendor/gems/spectacles/lib/spectacles.rb:37:in `trailer'
[home]/.rvm/gems/jruby-1.7.2@ballista/gems/activerecord-3.2.11/lib/active_record/schema_dumper.rb:28:in `dump'
[home]/.rvm/gems/jruby-1.7.2@ballista/gems/activerecord-3.2.11/lib/active_record/schema_dumper.rb:21:in `dump'
[home]/.rvm/gems/jruby-1.7.2@ballista/gems/activerecord-3.2.11/lib/active_record/railties/databases.rake:379:in `(root)'
org/jruby/RubyIO.java:1183:in `open'
[home]/.rvm/gems/jruby-1.7.2@ballista/gems/activerecord-3.2.11/lib/active_record/railties/databases.rake:378:in `(root)'
org/jruby/RubyProc.java:249:in `call'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyArray.java:1613:in `each'
org/jruby/RubyKernel.java:1046:in `load'
Tasks: TOP => db:schema:dump
(See full trace by running task with --trace)
```
