### PR TITLE
Fix postgres view dump returning unescaped double quotes

### DIFF
--- a/lib/spectacles/schema_statements/postgresql_adapter.rb
+++ b/lib/spectacles/schema_statements/postgresql_adapter.rb
@@ -4,7 +4,7 @@ module Spectacles
   module SchemaStatements
     module PostgreSQLAdapter
       include Spectacles::SchemaStatements::AbstractAdapter
-      
+
       def views(name = nil) #:nodoc:
         q = <<-SQL
         SELECT table_name, table_type
@@ -12,22 +12,23 @@ module Spectacles
          WHERE table_schema IN (#{schemas})
            AND table_type = 'VIEW'
         SQL
-        
+
         execute(q, name).map { |row| row['table_name'] }
       end
 
       def view_build_query(view, name = nil)
         q = <<-SQL
         SELECT view_definition
-          FROM information_schema.views 
+          FROM information_schema.views
          WHERE table_catalog = (SELECT catalog_name FROM information_schema.information_schema_catalog_name)
            AND table_schema IN (#{schemas})
            AND table_name = '#{view}'
         SQL
-        
-        select_value(q, name) or raise "No view called #{view} found"
+
+        view_sql = select_value(q, name) or raise "No view called #{view} found"
+        view_sql.gsub("\"", "\\\"")
       end
-      
+
     private
       def schemas
         schema_search_path.split(/,/).map { |p| quote(p) }.join(',')

--- a/specs/adapters/postgresql_adapter_spec.rb
+++ b/specs/adapters/postgresql_adapter_spec.rb
@@ -14,4 +14,16 @@ describe "Spectacles::SchemaStatements::PostgreSQLAdapter" do
 
   it_behaves_like "an adapter", "PostgreSQLAdapter"
   it_behaves_like "a view model"
+
+  describe "#view_build_query" do
+    test_base = Class.new do
+      extend Spectacles::SchemaStatements::PostgreSQLAdapter
+      def self.schema_search_path; ""; end
+      def self.select_value(_, _); "\"products\""; end;
+    end
+
+    it "should escape double-quotes returned by Postgres" do
+      test_base.view_build_query(:new_product_users).must_match(/\\"/)
+    end
+  end
 end


### PR DESCRIPTION
Howdy! We were using `spectacles` to interface with a fairly complex Postgres view, created with a SQL string literal in a migration. When the `create_view` call was serialized to Rails' `schema.rb`, it contained unescaped double-quotes and would throw errors when restoring from schema.

We're still not sure exactly when this is the case, but Postgres can return double-quotes in its `table_schema` for certain view tables. Our quick fix was to patch the `spectacles` Postgres adapter to manually escape the returned SQL before ActiveRecord serialized it to `schema.rb`.

Please let me know if there's anything we can do to get this pushed upstream, or if this isn't an appropriate place for the fix. Thanks!
