### PR TITLE
use current_schemas instead of search_path

### DIFF
--- a/lib/spectacles/schema_statements/postgresql_adapter.rb
+++ b/lib/spectacles/schema_statements/postgresql_adapter.rb
@@ -9,7 +9,7 @@ module Spectacles
         q = <<-SQL
         SELECT table_name, table_type
           FROM information_schema.tables
-         WHERE table_schema IN (#{schemas})
+         WHERE table_schema = ANY(current_schemas(false))
            AND table_type = 'VIEW'
         SQL
 
@@ -21,17 +21,12 @@ module Spectacles
         SELECT view_definition
           FROM information_schema.views
          WHERE table_catalog = (SELECT catalog_name FROM information_schema.information_schema_catalog_name)
-           AND table_schema IN (#{schemas})
+           AND table_schema = ANY(current_schemas(false))
            AND table_name = '#{view}'
         SQL
 
         view_sql = select_value(q, name) or raise "No view called #{view} found"
         view_sql.gsub("\"", "\\\"")
-      end
-
-    private
-      def schemas
-        schema_search_path.split(/,/).map { |p| quote(p) }.join(',')
       end
     end
   end


### PR DESCRIPTION
the search_path by default contains "$user", so if you're literally putting that in a query, it will not be evaluated to match schemas matching your username. current_schemas on the other hand returns the effective search path after it has been evaluated and checked against existing schemas