### PR TITLE
Materialized views

### DIFF
--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -38,6 +38,80 @@ Create a migration from an ARel object:
     # Your fancy methods
   end
 
+== Materialized Views
+
+*This feature is only supported for PostgreSQL backends.*
+These are essentially views that cache their result set. In this way
+they are kind of a cross between tables (which persist data) and views
+(which are windows onto other tables).
+
+  create_materialized_view :product_users do
+    <<-SQL.squish
+      SELECT name AS product_name, first_name AS username
+        FROM products
+        JOIN users ON users.id = products.user_id
+    SQL
+  end
+
+  class ProductUser < Spectacles::MaterializedView
+    # just like Spectacles::View
+  end
+
+Because these materialized views cache a snapshot of the data as it
+exists at a point in time (typically when the view was created), you
+need to manually _refresh_ the view when new data is added to the
+original tables. You can do this with the `#refresh!` method on
+the `Spectacles::MaterializedView` subclass:
+
+  User.create(first_name: "Bob", email: "bob@example.com")
+  ProductUser.refresh!
+
+Also, you can specify a few different options to `create_materialized_view`
+to affect how the new view is created:
+
+* `:force` - if `false` (the default), the create will fail if a
+  materialized view with the given name already exists. If `true`,
+  any materialized view with that name will be dropped before the
+  create runs.
+
+  create_materialized_view :product_users, force: true do
+    # ...
+  end
+
+* `:data` - if `true` (the default), the view is immediately populated
+  with the corresponding data. If `false`, the view will be empty initially,
+  and must be populated by invoking the `#refresh!` method.
+
+  create_materialized_view :product_users, data: false do
+    # ...
+  end
+
+* `:columns` - an optional array of names to give the columns in the view.
+  By default, columns in the view will use the names given in the query.
+
+  create_materialized_view :product_users, columns: %i(product_name username) do
+    <<-SQL.squish
+      SELECT products.name, users.first_name
+        FROM products
+        JOIN users ON users.id = products.user_id
+    SQL
+  end
+
+* `:tablespace` - an optional identifier (string or symbol) indicating
+  which namespace the materialized view ought to be created in.
+
+  create_materialized_view :product_users, tablespace: "awesomesauce" do
+    # ...
+  end
+
+* `:storage` - an optional hash of (database-specific) storage parameters to
+  optimize how the materialized view is stored. (See [the PostgreSQL documentation](http://www.postgresql.org/docs/9.4/static/sql-createtable.html#SQL-CREATETABLE-STORAGE-PARAMETERS)
+  for details.)
+
+  create_materialized_view :product_users, storage: { fillfactor: 70 } do
+    # ...
+  end
+
 = License
 
 Spectacles is licensed under MIT license (Read lib/spectactles.rb for full license)

--- a/Readme.rdoc
+++ b/Readme.rdoc
@@ -60,57 +60,58 @@ they are kind of a cross between tables (which persist data) and views
 Because these materialized views cache a snapshot of the data as it
 exists at a point in time (typically when the view was created), you
 need to manually _refresh_ the view when new data is added to the
-original tables. You can do this with the `#refresh!` method on
-the `Spectacles::MaterializedView` subclass:
+original tables. You can do this with the +#refresh!+ method on
+the +Spectacles::MaterializedView+ subclass:
 
   User.create(first_name: "Bob", email: "bob@example.com")
   ProductUser.refresh!
 
-Also, you can specify a few different options to `create_materialized_view`
+Also, you can specify a few different options to +create_materialized_view+
 to affect how the new view is created:
 
-* `:force` - if `false` (the default), the create will fail if a
-  materialized view with the given name already exists. If `true`,
+* +:force+ - if +false+ (the default), the create will fail if a
+  materialized view with the given name already exists. If +true+,
   any materialized view with that name will be dropped before the
   create runs.
 
-  create_materialized_view :product_users, force: true do
-    # ...
-  end
+    create_materialized_view :product_users, force: true do
+      # ...
+    end
 
-* `:data` - if `true` (the default), the view is immediately populated
-  with the corresponding data. If `false`, the view will be empty initially,
-  and must be populated by invoking the `#refresh!` method.
+* +:data+ - if +true+ (the default), the view is immediately populated
+  with the corresponding data. If +false+, the view will be empty initially,
+  and must be populated by invoking the +#refresh!+ method.
 
-  create_materialized_view :product_users, data: false do
-    # ...
-  end
+    create_materialized_view :product_users, data: false do
+      # ...
+    end
 
-* `:columns` - an optional array of names to give the columns in the view.
+* +:columns+ - an optional array of names to give the columns in the view.
   By default, columns in the view will use the names given in the query.
 
-  create_materialized_view :product_users, columns: %i(product_name username) do
-    <<-SQL.squish
-      SELECT products.name, users.first_name
-        FROM products
-        JOIN users ON users.id = products.user_id
-    SQL
-  end
+    create_materialized_view :product_users, columns: %i(product_name username) do
+      <<-SQL.squish
+        SELECT products.name, users.first_name
+          FROM products
+          JOIN users ON users.id = products.user_id
+      SQL
+    end
 
-* `:tablespace` - an optional identifier (string or symbol) indicating
+* +:tablespace+ - an optional identifier (string or symbol) indicating
   which namespace the materialized view ought to be created in.
 
-  create_materialized_view :product_users, tablespace: "awesomesauce" do
-    # ...
-  end
+    create_materialized_view :product_users, tablespace: "awesomesauce" do
+      # ...
+    end
 
-* `:storage` - an optional hash of (database-specific) storage parameters to
-  optimize how the materialized view is stored. (See [the PostgreSQL documentation](http://www.postgresql.org/docs/9.4/static/sql-createtable.html#SQL-CREATETABLE-STORAGE-PARAMETERS)
+* +:storage+ - an optional hash of (database-specific) storage parameters to
+  optimize how the materialized view is stored. (See
+  http://www.postgresql.org/docs/9.4/static/sql-createtable.html#SQL-CREATETABLE-STORAGE-PARAMETERS
   for details.)
 
-  create_materialized_view :product_users, storage: { fillfactor: 70 } do
-    # ...
-  end
+    create_materialized_view :product_users, storage: { fillfactor: 70 } do
+      # ...
+    end
 
 = License
 

--- a/lib/spectacles.rb
+++ b/lib/spectacles.rb
@@ -3,6 +3,7 @@ require 'active_support/core_ext'
 require 'spectacles/schema_statements'
 require 'spectacles/schema_dumper'
 require 'spectacles/view'
+require 'spectacles/materialized_view'
 require 'spectacles/version'
 require 'spectacles/configuration'
 
@@ -36,6 +37,7 @@ ActiveRecord::SchemaDumper.class_eval do
 
   def trailer(stream)
     ::Spectacles::SchemaDumper.dump_views(stream, @connection)
+    ::Spectacles::SchemaDumper.dump_materialized_views(stream, @connection)
     _spectacles_orig_trailer(stream)
   end
 end

--- a/lib/spectacles/materialized_view.rb
+++ b/lib/spectacles/materialized_view.rb
@@ -1,0 +1,39 @@
+module Spectacles
+  class MaterializedView < ActiveRecord::Base
+    self.abstract_class = true
+
+    def self.new(*)
+      raise NotImplementedError
+    end
+
+    def self.materialized_view_exists?
+      self.connection.materialized_view_exists?(self.view_name)
+    end
+
+    def self.refresh!
+      self.connection.refresh_materialized_view(self.view_name)
+    end
+
+    class << self
+      alias_method :table_exists?, :materialized_view_exists?
+      alias_method :view_name, :table_name
+    end
+
+    def ==(comparison_object)
+      super ||
+        comparison_object.instance_of?(self.class) &&
+        attributes.present? &&
+        comparison_object.attributes == attributes
+    end
+
+    def persisted?
+      false
+    end
+
+    def readonly?
+      true
+    end
+  end
+
+  ::ActiveSupport.run_load_hooks(:spectacles, MaterializedView)
+end

--- a/lib/spectacles/schema_dumper.rb
+++ b/lib/spectacles/schema_dumper.rb
@@ -20,9 +20,11 @@ module Spectacles
 
     def self.dump_view(stream, connection, view_name)
       stream.print <<-CREATEVIEW
+
   create_view :#{view_name}, :force => true do
     "#{connection.view_build_query(view_name)}"
   end
+
       CREATEVIEW
     end
 
@@ -31,8 +33,11 @@ module Spectacles
       options[:force] = true
 
       stream.print <<-CREATEVIEW
+
   create_materialized_view #{view_name.to_sym.inspect}, #{format_option_hash(options)} do
-    #{definition.inspect}
+    <<-SQL
+      #{definition}
+    SQL
   end
       CREATEVIEW
     end

--- a/lib/spectacles/schema_dumper.rb
+++ b/lib/spectacles/schema_dumper.rb
@@ -8,12 +8,49 @@ module Spectacles
       end
     end
 
+    def self.dump_materialized_views(stream, connection)
+      unless (Spectacles.config.enable_schema_dump == false)
+        if connection.supports_materialized_views?
+          connection.materialized_views.sort.each do |view|
+            dump_materialized_view(stream, connection, view)
+          end
+        end
+      end
+    end
+
     def self.dump_view(stream, connection, view_name)
       stream.print <<-CREATEVIEW
   create_view :#{view_name}, :force => true do
     "#{connection.view_build_query(view_name)}"
   end
       CREATEVIEW
+    end
+
+    def self.dump_materialized_view(stream, connection, view_name)
+      definition, options = connection.materialized_view_build_query(view_name)
+      options[:force] = true
+
+      stream.print <<-CREATEVIEW
+  create_materialized_view #{view_name.to_sym.inspect}, #{format_option_hash(options)} do
+    #{definition.inspect}
+  end
+      CREATEVIEW
+    end
+
+    def self.format_option_hash(hash)
+      hash.map do |key, value|
+        "#{key}: #{format_option_value(value)}"
+      end.join(", ")
+    end
+
+    def self.format_option_value(value)
+      case value
+      when Hash then "{ #{format_option_hash(value)} }"
+      when /^\d+$/ then value.to_i
+      when /^\d+\.\d+$/ then value.to_f
+      when true, false then value.inspect
+      else raise "can't format #{value.inspect}"
+      end
     end
   end
 end

--- a/lib/spectacles/schema_statements/abstract_adapter.rb
+++ b/lib/spectacles/schema_statements/abstract_adapter.rb
@@ -46,6 +46,34 @@ module Spectacles
       def views
         raise "Override view for your db adapter in #{self.class}"
       end
+
+      def supports_materialized_views?
+        false
+      end
+
+      def materialized_view_exists?(name)
+        return materialized_views.include?(name.to_s)
+      end
+
+      def materialized_views
+        raise NotImplementedError, "Override materialized_views for your db adapter in #{self.class}"
+      end
+
+      def materialized_view_build_query(view_name)
+        raise NotImplementedError, "Override materialized_view_build_query for your db adapter in #{self.class}"
+      end
+
+      def create_materialized_view(view_name, *args)
+        raise NotImplementedError, "Override create_materialized_view for your db adapter in #{self.class}"
+      end
+
+      def drop_materialized_view(view_name)
+        raise NotImplementedError, "Override drop_materialized_view for your db adapter in #{self.class}"
+      end
+
+      def refresh_materialized_view(view_name)
+        raise NotImplementedError, "Override refresh_materialized_view for your db adapter in #{self.class}"
+      end
     end
   end
 end

--- a/lib/spectacles/schema_statements/postgresql_adapter.rb
+++ b/lib/spectacles/schema_statements/postgresql_adapter.rb
@@ -28,6 +28,70 @@ module Spectacles
         view_sql = select_value(q, name) or raise "No view called #{view} found"
         view_sql.gsub("\"", "\\\"")
       end
+
+      def supports_materialized_views?
+        true
+      end
+
+      def create_materialized_view_statement(view_name, query, options={})
+        columns = if options[:columns]
+            "(" + options[:columns].map { |c| quote_column_name(c) }.join(",") + ")"
+          else
+            ""
+          end
+
+        storage = if options[:storage] && options[:storage].any?
+            "WITH " + options[:storage].map { |key, value| "#{key}=#{value}" }.join(", ")
+          else
+            ""
+          end
+
+        tablespace = if options[:tablespace]
+            "TABLESPACE #{quote_table_name(options[:tablespace])}"
+          else
+            ""
+          end
+
+        with_data = if options.fetch(:data, true)
+            "WITH DATA"
+          else
+            "WITH NO DATA"
+          end
+
+        <<-SQL.squish
+          CREATE MATERIALIZED VIEW #{quote_table_name(view_name)}
+            #{columns}
+            #{storage}
+            #{tablespace}
+            AS #{query}
+            #{with_data}
+        SQL
+      end
+
+      def create_materialized_view(view_name, *args)
+        options = args.extract_options!
+        build_query = args.shift
+
+        raise "#create_materialized_view requires a query or block" if build_query.nil? && !block_given?
+
+        build_query = yield if block_given?
+        build_query = build_query.to_sql if build_query.respond_to?(:to_sql)
+
+        if options[:force] && materialized_view_exists?(view_name)
+          drop_materialized_view(view_name)
+        end
+
+        query = create_materialized_view_statement(view_name, build_query, options)
+        execute(query)
+      end
+
+      def drop_materialized_view(view_name)
+        execute "DROP MATERIALIZED VIEW IF EXISTS #{quote_table_name(view_name)}"
+      end
+
+      def refresh_materialized_view(view_name)
+        execute "REFRESH MATERIALIZED VIEW #{quote_table_name(view_name)}"
+      end
     end
   end
 end

--- a/specs/adapters/postgresql_adapter_spec.rb
+++ b/specs/adapters/postgresql_adapter_spec.rb
@@ -15,15 +15,54 @@ describe "Spectacles::SchemaStatements::PostgreSQLAdapter" do
   it_behaves_like "an adapter", "PostgreSQLAdapter"
   it_behaves_like "a view model"
 
-  describe "#view_build_query" do
-    test_base = Class.new do
-      extend Spectacles::SchemaStatements::PostgreSQLAdapter
-      def self.schema_search_path; ""; end
-      def self.select_value(_, _); "\"products\""; end;
-    end
+  test_base = Class.new do
+    extend Spectacles::SchemaStatements::PostgreSQLAdapter
+    def self.schema_search_path; ""; end
+    def self.select_value(_, _); "\"products\""; end;
+    def self.quote_table_name(name); name; end
+    def self.quote_column_name(name); name; end
+  end
 
+  describe "#view_build_query" do
     it "should escape double-quotes returned by Postgres" do
       test_base.view_build_query(:new_product_users).must_match(/\\"/)
+    end
+  end
+
+  describe "#materialized_views" do
+    it "should support materialized views" do
+      test_base.supports_materialized_views?.must_equal true
+    end
+  end
+
+  describe "#create_materialized_view_statement" do
+    it "should work with no options" do
+      query = test_base.create_materialized_view_statement(:view_name, "select_query_here")
+      query.must_match(/create materialized view view_name as select_query_here with data/i)
+    end
+
+    it "should allow column names to be specified" do
+      query = test_base.create_materialized_view_statement(:view_name, "select_query_here",
+        columns: %i(first second third))
+      query.must_match(/create materialized view view_name \(first,second,third\) as select_query_here with data/i)
+    end
+
+    it "should allow storage parameters to be specified" do
+      query = test_base.create_materialized_view_statement(:view_name, "select_query_here",
+        storage: { bats_in_belfry: true, max_wingspan: 15 })
+      query.must_match(/create materialized view view_name with bats_in_belfry=true, max_wingspan=15 as select_query_here with data/i)
+    end
+
+    it "should allow tablespace to be specified" do
+      query = test_base.create_materialized_view_statement(:view_name, "select_query_here",
+        tablespace: :the_final_frontier)
+      query.must_match(/create materialized view view_name tablespace the_final_frontier as select_query_here with data/i)
+    end
+
+    it "should allow empty view to be created" do
+      query = test_base.create_materialized_view_statement(:view_name, "select_query_here",
+        data: false)
+      query.must_match(/create materialized view view_name as select_query_here with no data/i)
     end
   end
 end

--- a/specs/adapters/postgresql_adapter_spec.rb
+++ b/specs/adapters/postgresql_adapter_spec.rb
@@ -50,7 +50,7 @@ describe "Spectacles::SchemaStatements::PostgreSQLAdapter" do
     it "should allow storage parameters to be specified" do
       query = test_base.create_materialized_view_statement(:view_name, "select_query_here",
         storage: { bats_in_belfry: true, max_wingspan: 15 })
-      query.must_match(/create materialized view view_name with bats_in_belfry=true, max_wingspan=15 as select_query_here with data/i)
+      query.must_match(/create materialized view view_name with \(bats_in_belfry=true, max_wingspan=15\) as select_query_here with data/i)
     end
 
     it "should allow tablespace to be specified" do

--- a/specs/spectacles/schema_statements/abstract_adapter_spec.rb
+++ b/specs/spectacles/schema_statements/abstract_adapter_spec.rb
@@ -3,6 +3,17 @@ require 'spec_helper'
 describe Spectacles::SchemaStatements::AbstractAdapter do 
   class TestBase
     extend Spectacles::SchemaStatements::AbstractAdapter
+
+    def self.materialized_views
+      @materialized_views || super
+    end
+
+    def self.with_materialized_views(list)
+      @materialized_views = list
+      yield
+    ensure
+      @materialized_views = nil
+    end
   end
 
   describe "#create_view" do
@@ -16,4 +27,55 @@ describe Spectacles::SchemaStatements::AbstractAdapter do
       lambda { TestBase.views }.must_raise(RuntimeError)
     end
   end
+
+  describe "#supports_materialized_views?" do
+    it "returns false when accessed on AbstractAdapter" do
+      TestBase.supports_materialized_views?.must_equal false
+    end
+  end
+
+  describe "#materialized_views" do
+    it "throws error when accessed on AbstractAdapter" do
+      lambda { TestBase.materialized_views }.must_raise(NotImplementedError)
+    end
+  end
+
+  describe "#materialized_view_exists?" do
+    it "is true when materialized_views includes the view" do
+      TestBase.with_materialized_views(%w(alpha beta gamma)) do
+        TestBase.materialized_view_exists?(:beta).must_equal true
+      end
+    end
+
+    it "is false when materialized_views does not include the view" do
+      TestBase.with_materialized_views(%w(alpha beta gamma)) do
+        TestBase.materialized_view_exists?(:delta).must_equal false
+      end
+    end
+  end
+
+  describe "#materialized_view_build_query" do
+    it "throws error when accessed on AbstractAdapter" do
+      lambda { TestBase.materialized_view_build_query(:books) }.must_raise(NotImplementedError)
+    end
+  end
+
+  describe "#create_materialized_view" do
+    it "throws error when accessed on AbstractAdapter" do
+      lambda { TestBase.create_materialized_view(:books) }.must_raise(NotImplementedError)
+    end
+  end
+
+  describe "#drop_materialized_view" do
+    it "throws error when accessed on AbstractAdapter" do
+      lambda { TestBase.drop_materialized_view(:books) }.must_raise(NotImplementedError)
+    end
+  end
+
+  describe "#refresh_materialized_view" do
+    it "throws error when accessed on AbstractAdapter" do
+      lambda { TestBase.refresh_materialized_view(:books) }.must_raise(NotImplementedError)
+    end
+  end
+
 end

--- a/specs/support/minitest_shared.rb
+++ b/specs/support/minitest_shared.rb
@@ -12,9 +12,8 @@ module MiniTest::Spec::SharedExamples
   end
 
   def it_behaves_like(desc, *args)
-    self.instance_eval do
-      MiniTest::Spec.shared_examples[desc].call(*args)
-    end
+    examples = MiniTest::Spec.shared_examples[desc]
+    instance_exec(*args, &examples)
   end
 end
 

--- a/specs/support/schema_statement_examples.rb
+++ b/specs/support/schema_statement_examples.rb
@@ -3,6 +3,8 @@ require 'spec_helper'
 shared_examples_for "an adapter" do |adapter|
   shared_base = Class.new do
     extend Spectacles::SchemaStatements.const_get(adapter)
+    def self.quote_table_name(name); name; end
+    def self.quote_column_name(name); name; end
     def self.execute(query); query; end 
   end
 
@@ -92,6 +94,84 @@ shared_examples_for "an adapter" do |adapter|
 
       it "takes a string as the view_name" do 
         shared_base.drop_view(view_name.to_s).must_match(/#{view_name}/)
+      end
+    end
+  end
+
+  if shared_base.supports_materialized_views?
+    describe "#create_materialized_view" do
+      let(:view_name) { :view_name }
+
+      it "throws error when block not given and no build_query" do
+        lambda { shared_base.create_materialized_view(view_name) }.must_raise(RuntimeError)
+      end
+
+      describe "view_name" do
+        it "takes a symbol as the view_name" do
+          shared_base.create_materialized_view(view_name.to_sym, Product.all).must_match(/#{view_name}/)
+        end
+
+        it "takes a string as the view_name" do
+          shared_base.create_materialized_view(view_name.to_s, Product.all).must_match(/#{view_name}/)
+        end
+      end
+
+      describe "build_query" do
+        it "uses a string if passed" do
+          select_statement = "SELECT * FROM products"
+          shared_base.create_materialized_view(view_name, select_statement).must_match(/#{Regexp.escape(select_statement)}/)
+        end
+
+        it "uses an Arel::Relation if passed" do
+          select_statement = Product.all.to_sql
+          shared_base.create_materialized_view(view_name, Product.all).must_match(/#{Regexp.escape(select_statement)}/)
+        end
+      end
+
+      describe "block" do
+        it "can use an Arel::Relation from the yield" do
+          select_statement = Product.all.to_sql
+          shared_base.create_materialized_view(view_name) { Product.all }.must_match(/#{Regexp.escape(select_statement)}/)
+        end
+
+        it "can use a String from the yield" do
+          select_statement = "SELECT * FROM products"
+          shared_base.create_materialized_view(view_name) { "SELECT * FROM products" }.must_match(/#{Regexp.escape(select_statement)}/)
+        end
+      end
+    end
+
+    describe "#drop_materialized_view" do
+      let(:view_name) { :view_name }
+
+      describe "view_name" do
+        it "takes a symbol as the view_name" do
+          shared_base.drop_materialized_view(view_name.to_sym).must_match(/#{view_name}/)
+        end
+
+        it "takes a string as the view_name" do
+          shared_base.drop_materialized_view(view_name.to_s).must_match(/#{view_name}/)
+        end
+      end
+    end
+
+    describe "#refresh_materialized_view" do
+      let(:view_name) { :view_name }
+
+      describe "view_name" do
+        it "takes a symbol as the view_name" do
+          shared_base.refresh_materialized_view(view_name.to_sym).must_match(/#{view_name}/)
+        end
+
+        it "takes a string as the view_name" do
+          shared_base.refresh_materialized_view(view_name.to_s).must_match(/#{view_name}/)
+        end
+      end
+    end
+  else
+    describe "#materialized_views" do
+      it "should not be supported by #{adapter}" do
+        lambda { shared_base.materialized_views }.must_raise(NotImplementedError)
       end
     end
   end

--- a/specs/support/view_examples.rb
+++ b/specs/support/view_examples.rb
@@ -28,4 +28,33 @@ shared_examples_for "a view model" do
       end
     end
   end
+
+  if ActiveRecord::Base.connection.supports_materialized_views?
+    ActiveRecord::Base.connection.create_materialized_view(:materialized_product_users) do
+      "SELECT name AS product_name, first_name AS username FROM
+      products JOIN users ON users.id = products.user_id"
+    end
+
+    class MaterializedProductUser < Spectacles::MaterializedView
+      scope :duck_lovers, lambda { where(:product_name => 'Rubber Duck') }
+    end
+
+    describe "Spectacles::MaterializedView" do
+      before(:each) do
+        User.delete_all
+        Product.delete_all
+        @john = User.create(:first_name => 'John', :last_name => 'Doe')
+        @duck = @john.products.create(:name => 'Rubber Duck', :value => 10)
+        MaterializedProductUser.refresh!
+      end
+
+      it "can has scopes" do
+        MaterializedProductUser.duck_lovers.load.first.username.must_be @john.first_name
+      end
+
+      it "is readonly" do
+        MaterializedProductUser.first.readonly?.must_be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds support for materialized views in PostgreSQL. The implementation parallels that of regular views in many regards, but opts to keep the two features distinct (as PostgreSQL itself does).

Databases that do not support materialized views should not be affected at all by these changes. (They would simply not have access to the materialized views feature.)

As much as possible I've tried to follow the patterns and styles as implied by the existing code. Please let me know if anything ought to be done differently.