### PR TITLE
version bump - 0.6.0

### DIFF
--- a/lib/spectacles/version.rb
+++ b/lib/spectacles/version.rb
@@ -1,3 +1,3 @@
 module Spectacles
-  VERSION = "0.5.3"
+  VERSION = "0.6.0"
 end


### PR DESCRIPTION
This is a trivial change -- I'm only making a PR here because I wasn't sure how far to bump the version on this. As this is adding a new feature, but maintaining backwards-compatibility, it seems appropriate to bump the minor version, going from 0.5.3 to 0.6.0, but if you'd rather I just bumped the tiny version and go to 0.5.4, let me know.

Once this is good, I can go ahead and see about pushing a gem.