### PR TITLE
Fix broken sqlite tests

### DIFF
--- a/lib/spectacles/schema_statements.rb
+++ b/lib/spectacles/schema_statements.rb
@@ -10,7 +10,7 @@ module Spectacles
       if ActiveRecord::ConnectionAdapters.const_defined?(adapter_class)
         require "spectacles/schema_statements/#{db.downcase}_adapter"
         ActiveRecord::ConnectionAdapters.const_get(adapter_class).class_eval do
-          prepend Spectacles::SchemaStatements.const_get(adapter_class)
+          include Spectacles::SchemaStatements.const_get(adapter_class)
         end
       end
     end

--- a/lib/spectacles/schema_statements.rb
+++ b/lib/spectacles/schema_statements.rb
@@ -10,7 +10,7 @@ module Spectacles
       if ActiveRecord::ConnectionAdapters.const_defined?(adapter_class)
         require "spectacles/schema_statements/#{db.downcase}_adapter"
         ActiveRecord::ConnectionAdapters.const_get(adapter_class).class_eval do
-          include Spectacles::SchemaStatements.const_get(adapter_class)
+          prepend Spectacles::SchemaStatements.const_get(adapter_class)
         end
       end
     end

--- a/lib/spectacles/schema_statements/sqlite3_adapter.rb
+++ b/lib/spectacles/schema_statements/sqlite3_adapter.rb
@@ -1,9 +1,11 @@
 require 'spectacles/schema_statements/abstract_adapter'
+require 'spectacles/schema_statements/sqlite_backports'
 
 module Spectacles
   module SchemaStatements
     module SQLite3Adapter
       include Spectacles::SchemaStatements::AbstractAdapter
+      include Spectacles::SchemaStatements::SqliteBackports
 
       def generate_view_query(*columns)
         sql = <<-SQL

--- a/lib/spectacles/schema_statements/sqlite3_adapter.rb
+++ b/lib/spectacles/schema_statements/sqlite3_adapter.rb
@@ -4,8 +4,45 @@ require 'spectacles/schema_statements/sqlite_backports'
 module Spectacles
   module SchemaStatements
     module SQLite3Adapter
+      extend ActiveSupport::Concern
+
       include Spectacles::SchemaStatements::AbstractAdapter
       include Spectacles::SchemaStatements::SqliteBackports
+
+      # This rather ugly hack is necessary because of how Spectacles
+      # auto-installs itself. In spectacles.rb, an +inherited+ hook is
+      # defined that calls +Spectacles.load_adapters+ every time a new
+      # subclass of +ActiveRecord::ConnectionAdapter::AbstractAdapter+
+      # is defined. The problem is that the +inherited+ hook is called
+      # immediately after the class is opened, and before any methods
+      # have been added. Thus, when this module
+      # (+Spectacles::SchemaStatements::SQLite3Adapter+) gets
+      # included into the Rails adapter class, the adapter has no methods
+      # in it, which means any attempts to alias the +tables+ method (so
+      # it can be redefined) will fail (because the method doesn't exist
+      # yet). The solution implemented here checks to see if the +tables+
+      # method exists, and if it does not, it adds a +method_added+
+      # hook (yuck) and waits for the +tables+ method to be added. At
+      # that point, then, it sets up the aliases.
+      #
+      # Hardly ideal, but it seemed the least of all the other evil
+      # methods that occurred to me (overriding #require, etc.)
+      #
+      # The cleanest solution uses Module#prepend, but the need to
+      # support jRuby < 9k means we can't go that route yet.
+      included do
+        if instance_methods.include?(:tables)
+          alias_method :tables_with_views, :tables
+          alias_method :tables, :tables_without_views
+        else
+          def self.method_added(method_name)
+            if method_name == :tables && !instance_methods.include?(:tables_with_views)
+              alias_method :tables_with_views, :tables
+              alias_method :tables, :tables_without_views
+            end
+          end
+        end
+      end
 
       def generate_view_query(*columns)
         sql = <<-SQL

--- a/lib/spectacles/schema_statements/sqlite_adapter.rb
+++ b/lib/spectacles/schema_statements/sqlite_adapter.rb
@@ -1,9 +1,11 @@
 require 'spectacles/schema_statements/abstract_adapter'
+require 'spectacles/schema_statements/sqlite_backports'
 
 module Spectacles
   module SchemaStatements
     module SQLiteAdapter
       include Spectacles::SchemaStatements::AbstractAdapter
+      include Spectacles::SchemaStatements::SqliteBackports
 
       def generate_view_query(*columns)
         sql = <<-SQL

--- a/lib/spectacles/schema_statements/sqlite_backports.rb
+++ b/lib/spectacles/schema_statements/sqlite_backports.rb
@@ -1,0 +1,22 @@
+module Spectacles
+  module SchemaStatements
+    module SqliteBackports
+
+      # copied from ActiveRecord, because the sqlite3 adapter in AR
+      # tries to return both tables AND views with this method.
+      def tables(name = nil, table_name = nil) #:nodoc:
+        sql = <<-SQL
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'table' AND NOT name = 'sqlite_sequence'
+        SQL
+        sql << " AND name = #{quote_table_name(table_name)}" if table_name
+
+        exec_query(sql, 'SCHEMA').map do |row|
+          row['name']
+        end
+      end
+
+    end
+  end
+end

--- a/lib/spectacles/schema_statements/sqlite_backports.rb
+++ b/lib/spectacles/schema_statements/sqlite_backports.rb
@@ -4,7 +4,7 @@ module Spectacles
 
       # copied from ActiveRecord, because the sqlite3 adapter in AR
       # tries to return both tables AND views with this method.
-      def tables(name = nil, table_name = nil) #:nodoc:
+      def tables_without_views(name = nil, table_name = nil) #:nodoc:
         sql = <<-SQL
           SELECT name
           FROM sqlite_master

--- a/specs/adapters/sqlite_adapter_spec.rb
+++ b/specs/adapters/sqlite_adapter_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'spectacles/schema_statements/sqlite_adapter'
 
 describe "Spectacles::SchemaStatements::SQLiteAdapter" do
   File.delete(File.expand_path(File.dirname(__FILE__) + "/../test.db")) rescue nil


### PR DESCRIPTION
Addresses issue #12.

The problem here was that Rails' #tables method (for the sqlite adapter) was changed in early 2014 to return both tables, and views. This caused the schema dumper to dump views as tables, which broke Spectacle's sqlite tests which tried to load a dumped schema.

Overriding Rails' #tables method to return only tables fixes the tests here, but as I can only conjecture as to the original reason for that method return tables and views, I'm a little worried about collateral damage.