### PR TITLE
Fix broken mysql tests

### DIFF
--- a/lib/spectacles/schema_statements/mysql_adapter.rb
+++ b/lib/spectacles/schema_statements/mysql_adapter.rb
@@ -1,10 +1,12 @@
 require 'spectacles/schema_statements/abstract_adapter'
+require 'spectacles/schema_statements/mysql_backports'
 
 module Spectacles
   module SchemaStatements
     module MysqlAdapter
       include Spectacles::SchemaStatements::AbstractAdapter
-      
+      include Spectacles::SchemaStatements::MysqlBackports
+
       def views(name = nil) #:nodoc:
         execute("SHOW FULL TABLES WHERE TABLE_TYPE='VIEW'").map { |row| row[0] }
       end

--- a/lib/spectacles/schema_statements/mysql_backports.rb
+++ b/lib/spectacles/schema_statements/mysql_backports.rb
@@ -1,0 +1,27 @@
+module Spectacles
+  module SchemaStatements
+    module MysqlBackports
+
+      # Copied (and adapted) from ActiveRecord, because AR's
+      # default implementation for mysql returns both tables
+      # and views.
+      def tables(name = nil, database = nil, like = nil) #:nodoc:
+        database = database ? quote_table_name(database) : "DATABASE()"
+        by_name  = like ? "AND table_name LIKE #{quote(like)}" : ""
+
+        sql = <<-SQL.squish
+          SELECT table_name, table_type
+            FROM information_schema.tables
+           WHERE table_schema = #{database}
+             AND table_type = 'BASE TABLE'
+             #{by_name}
+        SQL
+
+        execute_and_free(sql, 'SCHEMA') do |result|
+          result.collect(&:first)
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
As with the sqlite-views branch, this fix works around Rails' default `#tables` behavior for mysql by forcing it to return only tables (not tables and views). (In all fairness, in this case it is mysql that is guilty of returning tables and views when asked for tables.)

Once again, it isn't clear what the larger implications of changing Rails' `#tables` method on the Mysql adapter, but it certainly seems like more accurate (and portable) behavior to have that return _only_ tables.