### PR TITLE
JRuby returns storage definition as an Array

### DIFF
--- a/lib/spectacles/schema_statements/postgresql_adapter.rb
+++ b/lib/spectacles/schema_statements/postgresql_adapter.rb
@@ -134,6 +134,10 @@ module Spectacles
       end
 
       def parse_storage_definition(storage)
+        # JRuby 9000 returns storage as an Array, whereas
+        # MRI returns a string.
+        storage = storage.first if storage.is_a?(Array)
+
         storage = storage.gsub(/^{|}$/, "")
         storage.split(/,/).inject({}) do |hash, item|
           key, value = item.strip.split(/=/)


### PR DESCRIPTION
Check storage_definition for type, and turn it into a string, if necessary.

Resolves #16

@ah @jamis 