### PR TITLE
Add concurrent refreshing of materialized views

### DIFF
--- a/lib/spectacles/materialized_view.rb
+++ b/lib/spectacles/materialized_view.rb
@@ -14,6 +14,11 @@ module Spectacles
       self.connection.refresh_materialized_view(self.view_name)
     end
 
+    def self.refresh_concurrently!
+      self.connection.refresh_materialized_view_concurrently(self.view_name)
+    end
+
+
     class << self
       alias_method :table_exists?, :materialized_view_exists?
       alias_method :view_name, :table_name

--- a/lib/spectacles/schema_statements/abstract_adapter.rb
+++ b/lib/spectacles/schema_statements/abstract_adapter.rb
@@ -74,6 +74,10 @@ module Spectacles
       def refresh_materialized_view(view_name)
         raise NotImplementedError, "Override refresh_materialized_view for your db adapter in #{self.class}"
       end
+      
+      def refresh_materialized_view_concurrently(view_name)
+        raise NotImplementedError, "Override refresh_materialized_view_concurrently for your db adapter in #{self.class}"
+      end
     end
   end
 end

--- a/lib/spectacles/schema_statements/postgresql_adapter.rb
+++ b/lib/spectacles/schema_statements/postgresql_adapter.rb
@@ -133,6 +133,10 @@ module Spectacles
         execute "REFRESH MATERIALIZED VIEW #{quote_table_name(view_name)}"
       end
 
+      def refresh_materialized_view_concurrently(view_name)
+        execute "REFRESH MATERIALIZED VIEW CONCURRENTLY #{quote_table_name(view_name)}"
+      end
+
       def parse_storage_definition(storage)
         # JRuby 9000 returns storage as an Array, whereas
         # MRI returns a string.

--- a/specs/spectacles/schema_statements/abstract_adapter_spec.rb
+++ b/specs/spectacles/schema_statements/abstract_adapter_spec.rb
@@ -77,5 +77,11 @@ describe Spectacles::SchemaStatements::AbstractAdapter do
       lambda { TestBase.refresh_materialized_view(:books) }.must_raise(NotImplementedError)
     end
   end
+  
+  describe "#refresh_materialized_view_concurrently" do
+    it "throws error when accessed on AbstractAdapter" do
+      lambda { TestBase.refresh_materialized_view_concurrently(:books) }.must_raise(NotImplementedError)
+    end
+  end
 
 end


### PR DESCRIPTION
PostgreSQL 9.4 added in the concurrently keyword. Added the methods to support that.
