### PR TITLE
Abstract adapter override fix

### DIFF
--- a/lib/spectacles.rb
+++ b/lib/spectacles.rb
@@ -6,6 +6,7 @@ require 'spectacles/view'
 require 'spectacles/materialized_view'
 require 'spectacles/version'
 require 'spectacles/configuration'
+require 'spectacles/abstract_adapter_override'
 
 require 'spectacles/railtie' if defined?(Rails)
 
@@ -20,15 +21,6 @@ module Spectacles
 
   class << self
     alias_method :config, :configuration
-  end
-end
-
-ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
-  alias_method(:_spectacles_original_inherited, :inherited) if method_defined?(:inherited)
-
-  def self.inherited(klass)
-    ::Spectacles::load_adapters
-    _spectacles_orig_inherited if method_defined?(:_spectacles_original_inherited)
   end
 end
 

--- a/lib/spectacles/abstract_adapter_override.rb
+++ b/lib/spectacles/abstract_adapter_override.rb
@@ -1,8 +1,10 @@
 ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
-  alias_method(:_spectacles_original_inherited, :inherited) if method_defined?(:inherited)
+  class << self
+    alias_method(:_spectacles_orig_inherited, :inherited) if method_defined?(:inherited)
 
-  def self.inherited(klass)
-    ::Spectacles::load_adapters
-    _spectacles_orig_inherited if method_defined?(:_spectacles_original_inherited)
+    def inherited(_subclass)
+      ::Spectacles::load_adapters
+      _spectacles_orig_inherited(_subclass) if methods.include?(:_spectacles_orig_inherited)
+    end
   end
 end

--- a/lib/spectacles/abstract_adapter_override.rb
+++ b/lib/spectacles/abstract_adapter_override.rb
@@ -1,0 +1,8 @@
+ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
+  alias_method(:_spectacles_original_inherited, :inherited) if method_defined?(:inherited)
+
+  def self.inherited(klass)
+    ::Spectacles::load_adapters
+    _spectacles_orig_inherited if method_defined?(:_spectacles_original_inherited)
+  end
+end

--- a/specs/spectacles/abstract_adapter_override_spec.rb
+++ b/specs/spectacles/abstract_adapter_override_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe "loading an adapter" do
+  it "calls the original AR::CA::AbstractAdapter.inherited method" do
+    ActiveRecord::ConnectionAdapters::AbstractAdapter.class_eval do
+      def self.inherited(subclass)
+        @_spectacles_inherited_called = true
+      end
+    end
+    load File.join(__dir__, '../../lib/spectacles/abstract_adapter_override.rb')
+    Class.new(ActiveRecord::ConnectionAdapters::AbstractAdapter)
+    ActiveRecord::ConnectionAdapters::AbstractAdapter.instance_variable_get("@_spectacles_inherited_called").must_equal true
+  end
+end


### PR DESCRIPTION
The code to override ActiveRecord::ConnectionAdapters::AbstractAdapter.inherited was not correctly storing and calling the original method if one had been set.