### PR TITLE
Get the user from the connection config

### DIFF
--- a/lib/spectacles/schema_statements/postgresql_adapter.rb
+++ b/lib/spectacles/schema_statements/postgresql_adapter.rb
@@ -149,7 +149,7 @@ module Spectacles
       end
 
       def database_username
-        ::ActiveRecord::Base.configurations["defaults"]["username"]
+        @config[:username]
       end
     end
   end


### PR DESCRIPTION
The new `database_user` method added to the PostgreSQL adapter in #23 was expecting to pull the database user from where Rails' stores the configuration it loads from the database.yml. This won't work for a couple reasons:

1. Spectacles is not Rails-dependent and thus won't always have a config to reference.
2. Even when it does, `ActiveRecord::Base.establish_connection` can be called with a different configuration (this is actually how the specs in this gem work, which why the PostgreSQL specs started failing after this was merged).

Additionally, the method was expecting a YAML file to have a config nested under "defaults", which is not standard and cannot be guaranteed to exist.

A safer way to solve this would be to get the database user from the config that was used to establish the current connection. Unfortunately, this means accessing an instance variable directly (i.e. the connection class does not provide a config method or attribute), but I don't see any other way to guarantee the correct database user for the current connection is returned.

// @mmmries @jamis 