### PR TITLE
Add support for skipping views during schema dump

### DIFF
--- a/lib/spectacles/configuration.rb
+++ b/lib/spectacles/configuration.rb
@@ -1,9 +1,10 @@
 module Spectacles
   class Configuration
-    attr_accessor :enable_schema_dump
+    attr_accessor :enable_schema_dump, :skip_views
 
     def initialize
       @enable_schema_dump = true
+      @skip_views = []
     end
   end
 end

--- a/lib/spectacles/railtie.rb
+++ b/lib/spectacles/railtie.rb
@@ -5,10 +5,13 @@ module Spectacles
   class Railtie < ::Rails::Railtie
     config.spectacles = ::ActiveSupport::OrderedOptions.new
 
-    initializer "spectacles.configure" do |app|
+    initializer 'spectacles.configure' do |app|
       Spectacles.configure do |config|
-        if app.config.spectacles.has_key?(:enable_schema_dump)
+        if app.config.spectacles.key?(:enable_schema_dump)
           config.enable_schema_dump = app.config.spectacles[:enable_schema_dump]
+        end
+        if app.config.spectacles.key?(:skip_views)
+          config.skip_views = app.config.spectacles[:skip_views]
         end
       end
     end

--- a/lib/spectacles/schema_dumper.rb
+++ b/lib/spectacles/schema_dumper.rb
@@ -1,17 +1,19 @@
 module Spectacles
   module SchemaDumper
     def self.dump_views(stream, connection)
-      unless (Spectacles.config.enable_schema_dump == false)
+      unless Spectacles.config.enable_schema_dump == false
         connection.views.sort.each do |view|
+          next if skip_view?(view)
           dump_view(stream, connection, view)
         end
       end
     end
 
     def self.dump_materialized_views(dumper, stream, connection)
-      unless (Spectacles.config.enable_schema_dump == false)
+      unless Spectacles.config.enable_schema_dump == false
         if connection.supports_materialized_views?
           connection.materialized_views.sort.each do |view|
+            next if skip_view?(view)
             dump_materialized_view(stream, connection, view)
             dumper.send(:indexes, view, stream)
           end
@@ -46,7 +48,7 @@ module Spectacles
     def self.format_option_hash(hash)
       hash.map do |key, value|
         "#{key}: #{format_option_value(value)}"
-      end.join(", ")
+      end.join(', ')
     end
 
     def self.format_option_value(value)
@@ -57,6 +59,10 @@ module Spectacles
       when true, false then value.inspect
       else raise "can't format #{value.inspect}"
       end
+    end
+
+    def self.skip_view?(view)
+      Spectacles.config.skip_views.any? { |item| item === view }
     end
   end
 end


### PR DESCRIPTION
Our database includes many views that are not directly controlled by the Rails application, so we need a way to skip those views when dumping the schema.
This PR introduces support for specifying a list of views to skip, where each item can be anything that responds to the `===` operator (e.g. a String or a Regexp).